### PR TITLE
test: add unit tests for fare calculation and trip history (#7)

### DIFF
--- a/history.py
+++ b/history.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-def save_trip_to_history(seconds_stopped, seconds_moving, total_fare):
+def save_trip_to_history(seconds_stopped, seconds_moving, total_fare, filename):
     """
     Guarda un registro del trayecto en un archivo de texto.
     Cada línea representa un viaje.
@@ -14,5 +14,5 @@ def save_trip_to_history(seconds_stopped, seconds_moving, total_fare):
         f"fare={total_fare:.2f}€\n"
     )
 
-    with open("trip_history.txt", "a", encoding="utf-8") as file:
+    with open(filename, "a", encoding="utf-8") as file:
         file.write(line)

--- a/tests/test_fare.py
+++ b/tests/test_fare.py
@@ -1,0 +1,53 @@
+# tests/test_fare.py
+
+import unittest
+from main import calculate_fare
+
+
+class TestCalculateFare(unittest.TestCase):
+    """
+    Conjunto de pruebas para la función calculate_fare.
+    """
+
+    def test_calculate_fare_only_stopped(self):
+        """
+        Si el taxi solo está parado, la tarifa debe ser
+        segundos_parado * 0.02.
+        """
+        # Arrange (preparar datos)
+        seconds_stopped = 10  # 10 segundos parado
+        seconds_moving = 0    # 0 en movimiento
+
+        # Act (ejecutar la función que queremos probar)
+        result = calculate_fare(seconds_stopped, seconds_moving)
+
+        # Assert (comprobar el resultado)
+        self.assertAlmostEqual(result, 0.20)
+
+    def test_calculate_fare_only_moving(self):
+        """
+        Si el taxi solo está en movimiento, la tarifa debe ser
+        segundos_movimiento * 0.05.
+        """
+        seconds_stopped = 0
+        seconds_moving = 10  # 10 segundos en movimiento
+
+        result = calculate_fare(seconds_stopped, seconds_moving)
+
+        self.assertAlmostEqual(result, 0.50)
+
+    def test_calculate_fare_mixed(self):
+        """
+        Si el taxi está parte parado y parte en movimiento,
+        la tarifa es la suma de ambos.
+        """
+        seconds_stopped = 10   # 10 * 0.02 = 0.20
+        seconds_moving = 20    # 20 * 0.05 = 1.00
+
+        result = calculate_fare(seconds_stopped, seconds_moving)
+
+        self.assertAlmostEqual(result, 1.20)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,37 @@
+import unittest
+import os
+from history import save_trip_to_history
+
+class TestHistory(unittest.TestCase):
+
+    def setUp(self):
+        """
+        Antes de cada test: creamos un archivo temporal.
+        """
+        self.test_file = "test_history.txt"
+        if os.path.exists(self.test_file):
+            os.remove(self.test_file)
+    
+    def tearDown(self):
+        """ Despues del test:borramos el archivo temporal."""
+        if os.path.exists(self.test_file):
+            os.remove(self.test_file)
+    
+    def test_save_trip_to_history_writes_line(self):
+        stopped = 10.0
+        moving = 20.0
+        total = 5.50
+
+        save_trip_to_history(stopped, moving, total, filename=self.test_file)
+
+        with open(self.test_file, "r", encoding="utf-8") as file:
+            content = file.read()
+
+        # Verificamos que los elementos correctos están en la línea 
+
+        self.assertIn("stopped=10.0s", content)
+        self.assertIn("moving=20.0s", content)
+        self.assertIn ("fare=5.50€", content)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Este PR añade pruebas unitarias completas para el proyecto:

- Tests para calculate_fare
- Tests para save_trip_to_history utilizando archivo temporal
- Refactor en history.py para permitir inyección de filename (facilita testing)
- Estructura de tests estandarizada

Issue relacionada: #7
